### PR TITLE
fix: supa-db-type-declaration

### DIFF
--- a/src/lib/transform-types.ts
+++ b/src/lib/transform-types.ts
@@ -45,9 +45,13 @@ export const transformTypes = z
     const enumNames: { name: string; formattedName: string }[] = [];
 
     sourceFile.forEachChild((n) => {
-      if (ts.isInterfaceDeclaration(n) && n.name.text === 'Database') {
+      if (
+        ts.isTypeAliasDeclaration(n) &&
+        ts.isTypeLiteralNode(n.type) &&
+        n.name.text === 'Database'
+      ) {
         // Database
-        n.forEachChild((n) => {
+        n.type.members.forEach((n) => {
           if (ts.isPropertySignature(n)) {
             // Schema
             const schemaName = getNodeName(n);


### PR DESCRIPTION
Since the recent supabase update, the Database schema type is now generated as a type instead of interface.