### PR TITLE
Fail on error, support array operations, CompositeTypes, quoted identifiers and single-member enums

### DIFF
--- a/src/lib/.gitignore
+++ b/src/lib/.gitignore
@@ -1,0 +1,2 @@
+temp.ts
+temp

--- a/src/lib/get-node-name.ts
+++ b/src/lib/get-node-name.ts
@@ -6,6 +6,11 @@ export const getNodeName = (n: ts.Node) => {
     if (ts.isIdentifier(n)) {
       name = n.text;
     }
+
+    // Handle quoted identifiers in case they contain special characters
+    if (ts.isStringLiteral(n)) {
+      name = n.text;
+    }
   });
   if (!name) throw new Error('Cannot get name of node');
   return name;

--- a/src/supabase-to-zod.ts
+++ b/src/supabase-to-zod.ts
@@ -49,10 +49,14 @@ export default async function supabaseToZod(opts: SupabaseToZodOptions) {
 
   const parsedTypes = transformTypes({ sourceText, ...opts });
 
-  const { getZodSchemasFile } = generate({
+  const { getZodSchemasFile, errors } = generate({
     sourceText: parsedTypes,
     ...opts,
   });
+
+  if (errors.length > 0) {
+    throw new Error(errors.join('\n'));
+  }
 
   const zodSchemasFile = getZodSchemasFile(
     getImportPath(outputPath, inputPath)


### PR DESCRIPTION
This makes the library capable of handling the TypeScript types as generated by recent versions of the Supabase CLI as well as makes it able to cover some more exotic scenarios like the aforementioned single-member enums and quoted identifiers.